### PR TITLE
Added Edit purchase order command

### DIFF
--- a/src/main/java/seedu/inventory/logic/commands/purchaseorder/EditPurchaseOrderCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/purchaseorder/EditPurchaseOrderCommand.java
@@ -1,0 +1,194 @@
+package seedu.inventory.logic.commands.purchaseorder;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.inventory.logic.parser.CliSyntax.PREFIX_QUANTITY;
+import static seedu.inventory.logic.parser.CliSyntax.PREFIX_REQDATE;
+import static seedu.inventory.logic.parser.CliSyntax.PREFIX_SUPPLIER;
+import static seedu.inventory.model.Model.PREDICATE_SHOW_ALL_PURCHASE_ORDER;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.inventory.commons.core.Messages;
+import seedu.inventory.commons.core.index.Index;
+import seedu.inventory.commons.util.CollectionUtil;
+import seedu.inventory.logic.CommandHistory;
+import seedu.inventory.logic.commands.Command;
+import seedu.inventory.logic.commands.CommandResult;
+import seedu.inventory.logic.commands.EditItemCommand;
+import seedu.inventory.logic.commands.exceptions.CommandException;
+import seedu.inventory.model.Model;
+import seedu.inventory.model.item.Quantity;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+import seedu.inventory.model.purchaseorder.RequiredDate;
+import seedu.inventory.model.purchaseorder.Supplier;
+
+/**
+ *
+ */
+public class EditPurchaseOrderCommand extends Command {
+
+    public static final String COMMAND_WORD = "edit-po";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the purchase order identified "
+            + "by the index number used in the displayed purchase order list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters that is editable: INDEX (must be a positive integer) "
+            + "[" + PREFIX_QUANTITY + "QUANTITY] "
+            + "[" + PREFIX_REQDATE + "REQUIRED DATE] "
+            + "[" + PREFIX_SUPPLIER + "SUPPLIER]\n "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_QUANTITY + "100 "
+            + PREFIX_REQDATE + "2018-12-12 "
+            + PREFIX_SUPPLIER + "Apple Inc.";
+
+    public static final String MESSAGE_EDIT_PO_SUCCESS = "Edited Purchase Order: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+
+    private final Index index;
+    private final EditPurchaseOrderCommand.EditPoDescriptor editPoDescriptor;
+
+    /**
+     * @param index            of the purchase order in the filtered purchase order list to edit
+     * @param editPoDescriptor details to edit the purchase order with
+     */
+    public EditPurchaseOrderCommand(Index index, EditPurchaseOrderCommand.EditPoDescriptor editPoDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editPoDescriptor);
+
+        this.index = index;
+        this.editPoDescriptor = new EditPurchaseOrderCommand.EditPoDescriptor(editPoDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<PurchaseOrder> lastShownList = model.getFilteredPurchaseOrderList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PO_DISPLAYED_INDEX);
+        }
+
+        PurchaseOrder purchaseOrderToEdit = lastShownList.get(index.getZeroBased());
+
+        if (!purchaseOrderToEdit.getStatus().equals(PurchaseOrder.Status.PENDING)) {
+            throw new CommandException(Messages.MESSAGE_SELECT_PENDING);
+        }
+
+        PurchaseOrder editedPurchaseOrder = createEditedPo(purchaseOrderToEdit, editPoDescriptor);
+
+        model.updatePurchaseOrder(purchaseOrderToEdit, editedPurchaseOrder);
+        model.updateFilteredPurchaseOrderList(PREDICATE_SHOW_ALL_PURCHASE_ORDER);
+        model.commitInventory();
+        return new CommandResult(String.format(MESSAGE_EDIT_PO_SUCCESS, editedPurchaseOrder));
+    }
+
+    /**
+     * Creates and returns a {@code PurchaseOrder} with the details of {@code poToEdit}
+     * edited with {@code editPoDescriptor}.
+     */
+    private static PurchaseOrder createEditedPo(PurchaseOrder poToEdit,
+                                                EditPurchaseOrderCommand.EditPoDescriptor editPoDescriptor) {
+        assert poToEdit != null;
+
+        Quantity updatedQuantity = editPoDescriptor.getQuantity().orElse(poToEdit.getQuantity());
+        RequiredDate updatedReqDate = editPoDescriptor.getRequiredDate().orElse(poToEdit.getReqDate());
+        Supplier updatedSupplier = editPoDescriptor.getSupplier().orElse(poToEdit.getSupplier());
+
+        return new PurchaseOrder(poToEdit.getSku(), updatedQuantity, updatedReqDate, updatedSupplier,
+                poToEdit.getStatus());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditItemCommand)) {
+            return false;
+        }
+
+        // state check
+        EditPurchaseOrderCommand e = (EditPurchaseOrderCommand) other;
+        return index.equals(e.index)
+                && editPoDescriptor.equals(e.editPoDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the item with. Each non-empty field value will replace the
+     * corresponding field value of the item.
+     */
+    public static class EditPoDescriptor {
+        private Quantity quantity;
+        private RequiredDate reqDate;
+        private Supplier supplier;
+
+        public EditPoDescriptor() {
+        }
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditPoDescriptor(EditPurchaseOrderCommand.EditPoDescriptor toCopy) {
+            setQuantity(toCopy.quantity);
+            setReqDate(toCopy.reqDate);
+            setSupplier(toCopy.supplier);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(quantity, reqDate, supplier);
+        }
+
+        public void setQuantity(Quantity quantity) {
+            this.quantity = quantity;
+        }
+
+        public Optional<Quantity> getQuantity() {
+            return Optional.ofNullable(quantity);
+        }
+
+        public void setReqDate(RequiredDate reqDate) {
+            this.reqDate = reqDate;
+        }
+
+        public Optional<RequiredDate> getRequiredDate() {
+            return Optional.ofNullable(reqDate);
+        }
+
+        public void setSupplier(Supplier supplier) {
+            this.supplier = supplier;
+        }
+
+        public Optional<Supplier> getSupplier() {
+            return Optional.ofNullable(supplier);
+        }
+
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditPurchaseOrderCommand.EditPoDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditPurchaseOrderCommand.EditPoDescriptor e = (EditPurchaseOrderCommand.EditPoDescriptor) other;
+
+            return getQuantity().equals(e.getQuantity())
+                    && getRequiredDate().equals(e.getRequiredDate())
+                    && getSupplier().equals(e.getSupplier());
+        }
+    }
+}

--- a/src/main/java/seedu/inventory/logic/parser/InventoryParser.java
+++ b/src/main/java/seedu/inventory/logic/parser/InventoryParser.java
@@ -27,7 +27,7 @@ import seedu.inventory.logic.commands.UndoCommand;
 import seedu.inventory.logic.commands.purchaseorder.AddPurchaseOrderCommand;
 import seedu.inventory.logic.commands.purchaseorder.ApprovePurchaseOrderCommand;
 import seedu.inventory.logic.commands.purchaseorder.DeletePurchaseOrderCommand;
-//import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
 import seedu.inventory.logic.commands.purchaseorder.ListPurchaseOrderCommand;
 import seedu.inventory.logic.commands.purchaseorder.RejectPurchaseOrderCommand;
 import seedu.inventory.logic.commands.sale.AddSaleCommand;
@@ -41,7 +41,7 @@ import seedu.inventory.logic.parser.exceptions.ParseException;
 import seedu.inventory.logic.parser.purchaseorder.AddPurchaseOrderCommandParser;
 import seedu.inventory.logic.parser.purchaseorder.ApprovePurchaseOrderCommandParser;
 import seedu.inventory.logic.parser.purchaseorder.DeletePurchaseOrderCommandParser;
-//import seedu.inventory.logic.parser.purchaseorder.EditPurchaseOrderCommandParser;
+import seedu.inventory.logic.parser.purchaseorder.EditPurchaseOrderCommandParser;
 import seedu.inventory.logic.parser.purchaseorder.RejectPurchaseOrderCommandParser;
 import seedu.inventory.logic.parser.sale.AddSaleCommandParser;
 import seedu.inventory.logic.parser.sale.DeleteSaleCommandParser;
@@ -147,8 +147,8 @@ public class InventoryParser {
         case RejectPurchaseOrderCommand.COMMAND_WORD:
             return new RejectPurchaseOrderCommandParser().parse(arguments);
 
-        //case EditPurchaseOrderCommand.COMMAND_WORD:
-            //eturn new EditPurchaseOrderCommandParser().parse(arguments);
+        case EditPurchaseOrderCommand.COMMAND_WORD:
+            return new EditPurchaseOrderCommandParser().parse(arguments);
 
         case AddSaleCommand.COMMAND_WORD:
             return new AddSaleCommandParser().parse(arguments);

--- a/src/main/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParser.java
+++ b/src/main/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParser.java
@@ -1,0 +1,58 @@
+package seedu.inventory.logic.parser.purchaseorder;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.inventory.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.inventory.logic.parser.CliSyntax.PREFIX_QUANTITY;
+import static seedu.inventory.logic.parser.CliSyntax.PREFIX_REQDATE;
+import static seedu.inventory.logic.parser.CliSyntax.PREFIX_SUPPLIER;
+
+import seedu.inventory.commons.core.index.Index;
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
+import seedu.inventory.logic.parser.ArgumentMultimap;
+import seedu.inventory.logic.parser.ArgumentTokenizer;
+import seedu.inventory.logic.parser.Parser;
+import seedu.inventory.logic.parser.ParserUtil;
+import seedu.inventory.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditPurchaseOrderCommand object
+ */
+public class EditPurchaseOrderCommandParser implements Parser<EditPurchaseOrderCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditPurchaseOrderCommand
+     * and returns an EditPurchaseOrderCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditPurchaseOrderCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_QUANTITY, PREFIX_REQDATE, PREFIX_SUPPLIER);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditPurchaseOrderCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditPurchaseOrderCommand.EditPoDescriptor editPoDescriptor = new EditPurchaseOrderCommand.EditPoDescriptor();
+        if (argMultimap.getValue(PREFIX_QUANTITY).isPresent()) {
+            editPoDescriptor.setQuantity(ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_QUANTITY).get()));
+        }
+        if (argMultimap.getValue(PREFIX_REQDATE).isPresent()) {
+            editPoDescriptor.setReqDate(ParserUtil.parseReqDate(argMultimap.getValue(PREFIX_REQDATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_SUPPLIER).isPresent()) {
+            editPoDescriptor.setSupplier(ParserUtil.parseSupplier(argMultimap.getValue(PREFIX_SUPPLIER).get()));
+        }
+
+        if (!editPoDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditPurchaseOrderCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditPurchaseOrderCommand(index, editPoDescriptor);
+    }
+}

--- a/src/test/java/seedu/inventory/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/inventory/logic/commands/CommandTestUtil.java
@@ -21,6 +21,7 @@ import java.util.List;
 import seedu.inventory.commons.core.index.Index;
 import seedu.inventory.logic.CommandHistory;
 import seedu.inventory.logic.commands.exceptions.CommandException;
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
 import seedu.inventory.logic.commands.staff.EditStaffCommand;
 import seedu.inventory.model.Inventory;
 import seedu.inventory.model.Model;
@@ -30,6 +31,7 @@ import seedu.inventory.model.purchaseorder.PurchaseOrder;
 import seedu.inventory.model.staff.Staff;
 import seedu.inventory.model.staff.StaffNameContainsKeywordsPredicate;
 import seedu.inventory.testutil.EditItemDescriptorBuilder;
+import seedu.inventory.testutil.purchaseorder.EditPurchaseOrderDescriptorBuilder;
 import seedu.inventory.testutil.staff.EditStaffDescriptorBuilder;
 
 /**
@@ -131,6 +133,16 @@ public class CommandTestUtil {
                 .withPassword(VALID_PASSWORD_ZUL).withRole(ROLE_DESC_ADMIN).build();
         DESC_DARREN = new EditStaffDescriptorBuilder().withName(VALID_NAME_DARREN).withUsername(VALID_USERNAME_DARREN)
                 .withPassword(VALID_PASSWORD_DARREN).withRole(ROLE_DESC_ADMIN).build();
+    }
+
+    public static final EditPurchaseOrderCommand.EditPoDescriptor DESC_OPPO_PO;
+    public static final EditPurchaseOrderCommand.EditPoDescriptor DESC_SONY_PO;
+
+    static {
+        DESC_OPPO_PO = new EditPurchaseOrderDescriptorBuilder().withQuantity(VALID_QUANTITY_OPPO)
+                .withRequiredDate(VALID_REQUIRED_DATE_OPPO).withSupplier(VALID_SUPPLIER_OPPO).build();
+        DESC_SONY_PO = new EditPurchaseOrderDescriptorBuilder().withQuantity(VALID_QUANTITY_SONY)
+                .withRequiredDate(VALID_REQUIRED_DATE_SONY).withSupplier(VALID_SUPPLIER_SONY).build();
     }
 
     /**

--- a/src/test/java/seedu/inventory/logic/commands/purchaseorder/EditPurchaseOrderCommandTest.java
+++ b/src/test/java/seedu/inventory/logic/commands/purchaseorder/EditPurchaseOrderCommandTest.java
@@ -1,0 +1,144 @@
+package seedu.inventory.logic.commands.purchaseorder;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static seedu.inventory.logic.commands.CommandTestUtil.DESC_OPPO_PO;
+import static seedu.inventory.logic.commands.CommandTestUtil.DESC_SONY_PO;
+import static seedu.inventory.logic.commands.CommandTestUtil.VALID_QUANTITY_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.VALID_REQUIRED_DATE_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.VALID_SUPPLIER_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.inventory.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.inventory.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.inventory.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.inventory.testutil.TypicalItems.getTypicalInventoryWithPo;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.inventory.commons.core.Messages;
+import seedu.inventory.commons.core.index.Index;
+import seedu.inventory.logic.CommandHistory;
+import seedu.inventory.logic.commands.ClearCommand;
+import seedu.inventory.logic.commands.RedoCommand;
+import seedu.inventory.logic.commands.UndoCommand;
+import seedu.inventory.logic.commands.exceptions.CommandException;
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand.EditPoDescriptor;
+
+import seedu.inventory.model.Inventory;
+import seedu.inventory.model.Model;
+import seedu.inventory.model.ModelManager;
+import seedu.inventory.model.SaleList;
+import seedu.inventory.model.UserPrefs;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+import seedu.inventory.testutil.purchaseorder.EditPurchaseOrderDescriptorBuilder;
+import seedu.inventory.testutil.purchaseorder.PurchaseOrderBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand)
+ * and unit tests for EditPurchaseOrderCommand.
+ */
+public class EditPurchaseOrderCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+    private Model model = new ModelManager(getTypicalInventoryWithPo(), new UserPrefs(), new SaleList());
+
+    @Test
+    public void execute_invalidIndexUnfilteredPoList_throwsCommandException() throws Exception {
+        Index invalidPoIndex = Index.fromOneBased(model.getFilteredPurchaseOrderList().size() + 1);
+        EditPurchaseOrderCommand cmd = new EditPurchaseOrderCommand(invalidPoIndex, DESC_OPPO_PO);
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(Messages.MESSAGE_INVALID_PO_DISPLAYED_INDEX);
+        cmd.execute(model, commandHistory);
+    }
+
+    @Test
+    public void execute_nonPendingPurchaseOrder_throwsCommandException() throws Exception {
+        ApprovePurchaseOrderCommand cmd = new ApprovePurchaseOrderCommand(INDEX_FIRST_ITEM);
+        cmd.execute(model, commandHistory);
+        EditPurchaseOrderCommand secondCmd = new EditPurchaseOrderCommand(INDEX_FIRST_ITEM, DESC_OPPO_PO);
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(Messages.MESSAGE_SELECT_PENDING);
+        secondCmd.execute(model, commandHistory);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastPo = Index.fromOneBased(model.getFilteredPurchaseOrderList().size());
+        PurchaseOrder lastPo = model.getFilteredPurchaseOrderList().get(indexLastPo.getZeroBased());
+
+        PurchaseOrderBuilder poInList = new PurchaseOrderBuilder(lastPo);
+        PurchaseOrder editedPo = poInList.withQuantity(VALID_QUANTITY_SONY).withRequiredDate(VALID_REQUIRED_DATE_SONY)
+                .withSupplier(VALID_SUPPLIER_SONY).build();
+
+        EditPoDescriptor descriptor = new EditPurchaseOrderDescriptorBuilder()
+                .withQuantity(VALID_QUANTITY_SONY).withRequiredDate(VALID_REQUIRED_DATE_SONY)
+                .withSupplier(VALID_SUPPLIER_SONY).build();
+
+        EditPurchaseOrderCommand editPoCommand = new EditPurchaseOrderCommand(indexLastPo, descriptor);
+
+        String expectedMessage = String.format(EditPurchaseOrderCommand.MESSAGE_EDIT_PO_SUCCESS, editedPo);
+
+        Model expectedModel = new ModelManager(new Inventory(model.getInventory()), new UserPrefs(), new SaleList());
+        expectedModel.updatePurchaseOrder(lastPo, editedPo);
+        expectedModel.commitInventory();
+
+        assertCommandSuccess(editPoCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditPurchaseOrderCommand editPoCommand = new EditPurchaseOrderCommand(INDEX_FIRST_ITEM, new EditPoDescriptor());
+        PurchaseOrder editedPo = model.getFilteredPurchaseOrderList().get(INDEX_FIRST_ITEM.getZeroBased());
+
+        String expectedMessage = String.format(EditPurchaseOrderCommand.MESSAGE_EDIT_PO_SUCCESS, editedPo);
+
+        Model expectedModel = new ModelManager(new Inventory(model.getInventory()), new UserPrefs(), new SaleList());
+        expectedModel.commitInventory();
+
+        assertCommandSuccess(editPoCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPurchaseOrderList().size() + 1);
+        EditPurchaseOrderCommand.EditPoDescriptor descriptor =
+                new EditPurchaseOrderDescriptorBuilder().withQuantity(VALID_QUANTITY_SONY).build();
+        EditPurchaseOrderCommand editPoCommand = new EditPurchaseOrderCommand(outOfBoundIndex, descriptor);
+
+        // execution failed -> inventory state not added into model
+        assertCommandFailure(editPoCommand, model, commandHistory, Messages.MESSAGE_INVALID_PO_DISPLAYED_INDEX);
+
+        // single inventory state in model -> undoCommand and redoCommand fail
+        assertCommandFailure(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_FAILURE);
+    }
+
+    @Test
+    public void equals() {
+        final EditPurchaseOrderCommand standardCommand = new EditPurchaseOrderCommand(INDEX_FIRST_ITEM, DESC_OPPO_PO);
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditPurchaseOrderCommand(INDEX_SECOND_ITEM, DESC_OPPO_PO)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditPurchaseOrderCommand(INDEX_FIRST_ITEM, DESC_SONY_PO)));
+    }
+
+}

--- a/src/test/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParserTest.java
+++ b/src/test/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParserTest.java
@@ -1,0 +1,82 @@
+package seedu.inventory.logic.parser.purchaseorder;
+
+import static seedu.inventory.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.inventory.logic.commands.CommandTestUtil.DESC_SONY_PO;
+import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_QUANTITY_DESC;
+import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_REQUIRED_DATE_DESC;
+import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_SUPPLIER_DESC;
+import static seedu.inventory.logic.commands.CommandTestUtil.QUANTITY_DESC_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.REQUIRED_DATE_DESC_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.VALID_QUANTITY_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.VALID_SUPPLIER_OPPO;
+import static seedu.inventory.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.inventory.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.inventory.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+
+import org.junit.Test;
+
+import seedu.inventory.commons.core.index.Index;
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
+import seedu.inventory.model.item.Quantity;
+import seedu.inventory.model.purchaseorder.RequiredDate;
+import seedu.inventory.model.purchaseorder.Supplier;
+
+
+public class EditPurchaseOrderCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditPurchaseOrderCommand.MESSAGE_USAGE);
+
+    private EditPurchaseOrderCommandParser parser = new EditPurchaseOrderCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_QUANTITY_SONY, EditPurchaseOrderCommand.MESSAGE_NOT_EDITED);
+
+        // no field specified
+        assertParseFailure(parser, "1", EditPurchaseOrderCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + QUANTITY_DESC_SONY, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + QUANTITY_DESC_SONY, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 u/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_QUANTITY_DESC,
+                Quantity.MESSAGE_QUANTITY_CONSTRAINTS); // invalid quantity
+        assertParseFailure(parser, "1" + INVALID_REQUIRED_DATE_DESC,
+                RequiredDate.MESSAGE_DATE_CONSTRAINTS); // invalid required date
+        assertParseFailure(parser, "1" + INVALID_SUPPLIER_DESC,
+                Supplier.MESSAGE_SUPPLIER_CONSTRAINTS); // invalid supplier
+
+
+        // invalid quantity followed by valid date
+        assertParseFailure(parser, "1" + INVALID_QUANTITY_DESC + REQUIRED_DATE_DESC_SONY,
+                Quantity.MESSAGE_QUANTITY_CONSTRAINTS);
+
+        // valid quantity followed by invalid quantity
+        assertParseFailure(parser, "1" + QUANTITY_DESC_SONY + INVALID_QUANTITY_DESC,
+                Quantity.MESSAGE_QUANTITY_CONSTRAINTS);
+
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_QUANTITY_DESC + INVALID_REQUIRED_DATE_DESC + VALID_SUPPLIER_OPPO,
+                Quantity.MESSAGE_QUANTITY_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParserTest.java
+++ b/src/test/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.inventory.logic.parser.purchaseorder;
 
 import static seedu.inventory.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.inventory.logic.commands.CommandTestUtil.DESC_SONY_PO;
 import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_QUANTITY_DESC;
 import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_REQUIRED_DATE_DESC;
 import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_SUPPLIER_DESC;
@@ -10,12 +9,9 @@ import static seedu.inventory.logic.commands.CommandTestUtil.REQUIRED_DATE_DESC_
 import static seedu.inventory.logic.commands.CommandTestUtil.VALID_QUANTITY_SONY;
 import static seedu.inventory.logic.commands.CommandTestUtil.VALID_SUPPLIER_OPPO;
 import static seedu.inventory.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.inventory.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.inventory.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
 import org.junit.Test;
 
-import seedu.inventory.commons.core.index.Index;
 import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
 import seedu.inventory.model.item.Quantity;
 import seedu.inventory.model.purchaseorder.RequiredDate;

--- a/src/test/java/seedu/inventory/testutil/purchaseorder/EditPurchaseOrderDescriptorBuilder.java
+++ b/src/test/java/seedu/inventory/testutil/purchaseorder/EditPurchaseOrderDescriptorBuilder.java
@@ -1,0 +1,62 @@
+package seedu.inventory.testutil.purchaseorder;
+
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand.EditPoDescriptor;
+import seedu.inventory.model.item.Quantity;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+import seedu.inventory.model.purchaseorder.RequiredDate;
+import seedu.inventory.model.purchaseorder.Supplier;
+
+/**
+ * An utility class to help with building EditPurchaseOrderDescriptor objects.
+ */
+public class EditPurchaseOrderDescriptorBuilder {
+    private EditPoDescriptor descriptor;
+
+    public EditPurchaseOrderDescriptorBuilder() {
+        this.descriptor = new EditPoDescriptor();
+    }
+
+    public EditPurchaseOrderDescriptorBuilder(EditPoDescriptor descriptor) {
+        this.descriptor = new EditPoDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditPurchaseOrderDescriptor} with fields containing {@code purchaseOrder}'s details
+     */
+    public EditPurchaseOrderDescriptorBuilder(PurchaseOrder purchaseOrder) {
+        descriptor = new EditPoDescriptor();
+        descriptor.setQuantity(purchaseOrder.getQuantity());
+        descriptor.setReqDate(purchaseOrder.getReqDate());
+        descriptor.setSupplier(purchaseOrder.getSupplier());
+    }
+
+    /**
+     * Sets the {@code Quantity} of the {@code EditPurchaseOrderDescriptor} that we are building.
+     */
+    public EditPurchaseOrderDescriptorBuilder withQuantity(String qty) {
+        descriptor.setQuantity(new Quantity(qty));
+        return this;
+    }
+
+    /**
+     * Sets the {@code RequiredDate} of the {@code EditPurchaseOrderDescriptor} that we are building.
+     */
+    public EditPurchaseOrderDescriptorBuilder withRequiredDate(String reqDate) {
+        descriptor.setReqDate(new RequiredDate(reqDate));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Supplier} of the {@code EditPurchaseOrderDescriptor} that we are building.
+     */
+    public EditPurchaseOrderDescriptorBuilder withSupplier(String supplier) {
+        descriptor.setSupplier(new Supplier(supplier));
+        return this;
+    }
+
+    public EditPoDescriptor build() {
+        return descriptor;
+    }
+
+
+}

--- a/src/test/java/seedu/inventory/testutil/purchaseorder/PurchaseOrderUtil.java
+++ b/src/test/java/seedu/inventory/testutil/purchaseorder/PurchaseOrderUtil.java
@@ -6,6 +6,7 @@ import static seedu.inventory.logic.parser.CliSyntax.PREFIX_SKU;
 import static seedu.inventory.logic.parser.CliSyntax.PREFIX_SUPPLIER;
 
 import seedu.inventory.logic.commands.purchaseorder.AddPurchaseOrderCommand;
+import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand.EditPoDescriptor;
 import seedu.inventory.model.purchaseorder.PurchaseOrder;
 
 /**
@@ -28,6 +29,19 @@ public class PurchaseOrderUtil {
         sb.append(PREFIX_QUANTITY + po.getQuantity().value + " ");
         sb.append(PREFIX_REQDATE + po.getReqDate().requiredDate + " ");
         sb.append(PREFIX_SUPPLIER + po.getSupplier().supplierName + " ");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the part of command string for the given {@code EditPoDescriptor}'s details.
+     */
+    public static String getEditPoDescriptorDetails(EditPoDescriptor descriptor) {
+        StringBuilder sb = new StringBuilder();
+        descriptor.getQuantity().ifPresent(quantity -> sb.append(PREFIX_QUANTITY).append(quantity.value).append(" "));
+        descriptor.getRequiredDate().ifPresent(reqDate -> sb.append(PREFIX_REQDATE).append(reqDate.requiredDate)
+                .append(" "));
+        descriptor.getSupplier().ifPresent(supplier -> sb.append(PREFIX_SUPPLIER).append(supplier).append(" "));
+
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/inventory/testutil/purchaseorder/TypicalPurchaseOrder.java
+++ b/src/test/java/seedu/inventory/testutil/purchaseorder/TypicalPurchaseOrder.java
@@ -74,7 +74,7 @@ public class TypicalPurchaseOrder {
     }
 
     public static List<PurchaseOrder> getTypicalPurchaseOrder() {
-        return new ArrayList<>(Arrays.asList(LGPO, SAMSUNGNOTEPO));
+        return new ArrayList<>(Arrays.asList(LGPO, OPPOPO, SAMSUNGNOTEPO, SONYPO));
     }
 
 }


### PR DESCRIPTION
This PR resolves #47 

### Added the command: `edit-po`
User can only edit pending purchase orders.
The only parameter that can be updated is: _Quantity, Required Date and Supplier_