### PR TITLE
Fixed edit item and purchase order bug + more test cases

### DIFF
--- a/src/main/java/seedu/inventory/logic/commands/item/EditItemCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/item/EditItemCommand.java
@@ -55,12 +55,15 @@ public class EditItemCommand extends Command {
     public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited Item: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the inventory.";
+    public static final String MESSAGE_ALSO_EDITED_PURCHASE_ORDER =
+            "\nThe relevant purchase orders's sku has been automatically updated.";
+    private static String messageFinal = MESSAGE_EDIT_ITEM_SUCCESS;
 
     private final Index index;
     private final EditItemDescriptor editItemDescriptor;
 
     /**
-     * @param index of the item in the filtered item list to edit
+     * @param index              of the item in the filtered item list to edit
      * @param editItemDescriptor details to edit the item with
      */
     public EditItemCommand(Index index, EditItemDescriptor editItemDescriptor) {
@@ -89,8 +92,14 @@ public class EditItemCommand extends Command {
 
         model.updateItem(itemToEdit, editedItem);
         model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
+
+        if (!itemToEdit.getSku().equals(editedItem.getSku()) && model.hasPurchaseOrder(itemToEdit)) {
+            model.updatePurchaseOrder(itemToEdit, editedItem);
+            messageFinal += MESSAGE_ALSO_EDITED_PURCHASE_ORDER;
+        }
+
         model.commitInventory();
-        return new CommandResult(String.format(MESSAGE_EDIT_ITEM_SUCCESS, editedItem));
+        return new CommandResult(String.format(messageFinal, editedItem));
     }
 
     /**
@@ -140,7 +149,8 @@ public class EditItemCommand extends Command {
         private Image image;
         private Set<Tag> tags;
 
-        public EditItemDescriptor() {}
+        public EditItemDescriptor() {
+        }
 
         /**
          * Copy constructor.

--- a/src/main/java/seedu/inventory/logic/commands/purchaseorder/EditPurchaseOrderCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/purchaseorder/EditPurchaseOrderCommand.java
@@ -16,7 +16,6 @@ import seedu.inventory.logic.CommandHistory;
 import seedu.inventory.logic.commands.Command;
 import seedu.inventory.logic.commands.CommandResult;
 import seedu.inventory.logic.commands.exceptions.CommandException;
-import seedu.inventory.logic.commands.item.EditItemCommand;
 import seedu.inventory.model.Model;
 import seedu.inventory.model.item.Quantity;
 import seedu.inventory.model.purchaseorder.PurchaseOrder;
@@ -107,7 +106,7 @@ public class EditPurchaseOrderCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditItemCommand)) {
+        if (!(other instanceof EditPurchaseOrderCommand)) {
             return false;
         }
 

--- a/src/main/java/seedu/inventory/model/Inventory.java
+++ b/src/main/java/seedu/inventory/model/Inventory.java
@@ -204,7 +204,7 @@ public class Inventory implements ReadOnlyInventory {
     }
 
     /**
-     * Returns true if a purchase order with the same identity as {@code po} exists in the inventory.
+     * Returns true if a purchase order with the same that has {@code item} exists in the inventory.
      */
     public boolean hasPurchaseOrder(Item item) {
         requireNonNull(item);
@@ -225,13 +225,36 @@ public class Inventory implements ReadOnlyInventory {
     }
 
     /**
-     * Replaces the given item {@code target} in the list with {@code editedPurchaseOrder}.
+     * Replaces the given purchase order {@code target} in the list with {@code editedPurchaseOrder}.
      * {@code target} must exist in the purchase order list.
      */
     public void updatePurchaseOrder(PurchaseOrder target, PurchaseOrder editedPurchaseOrder) {
         requireNonNull(editedPurchaseOrder);
 
         purchaseOrders.setPurchaseOrder(target, editedPurchaseOrder);
+    }
+
+    /**
+     * Replaces all purchase order sku in the list with {@code editedItem} sku.
+     */
+    public void updatePurchaseOrder(Item target, Item editedItem) {
+        requireNonNull(editedItem);
+
+        Iterator<PurchaseOrder> poList = purchaseOrders.iterator();
+
+        while (poList.hasNext()) {
+            PurchaseOrder po = poList.next();
+            if (po.getSku().equals(target.getSku())) {
+                PurchaseOrder editedPo = new PurchaseOrder(
+                        editedItem.getSku(),
+                        po.getQuantity(),
+                        po.getReqDate(),
+                        po.getSupplier(),
+                        po.getStatus());
+
+                purchaseOrders.setPurchaseOrder(po, editedPo);
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/inventory/model/Model.java
+++ b/src/main/java/seedu/inventory/model/Model.java
@@ -216,6 +216,11 @@ public interface Model {
     void updatePurchaseOrder(PurchaseOrder target, PurchaseOrder editedPurchaseOrder);
 
     /**
+     * Replaces all purchase order sku in the list with {@code editedItem} sku.
+     */
+    void updatePurchaseOrder(Item target, Item editedItem);
+
+    /**
      * Approves the given purchaseorder {@code target} and add the quantity to the item.
      * {@code target} must exist in the inventory.
      */

--- a/src/main/java/seedu/inventory/model/ModelManager.java
+++ b/src/main/java/seedu/inventory/model/ModelManager.java
@@ -291,6 +291,13 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public void updatePurchaseOrder(Item target, Item editedItem) {
+        requireAllNonNull(target, editedItem);
+        versionedInventory.updatePurchaseOrder(target, editedItem);
+        indicateInventoryChanged();
+    }
+
+    @Override
     public void approvePurchaseOrder(PurchaseOrder target) {
         versionedInventory.approvePurchaseOrder(target);
         indicateInventoryChanged();

--- a/src/main/java/seedu/inventory/ui/purchaseorder/PurchaseOrderCard.java
+++ b/src/main/java/seedu/inventory/ui/purchaseorder/PurchaseOrderCard.java
@@ -58,7 +58,7 @@ public class PurchaseOrderCard extends UiPart<Region> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof PurchaseOrder)) {
+        if (!(other instanceof PurchaseOrderCard)) {
             return false;
         }
 

--- a/src/test/java/guitests/guihandles/PurchaseOrderCardHandle.java
+++ b/src/test/java/guitests/guihandles/PurchaseOrderCardHandle.java
@@ -1,0 +1,71 @@
+package guitests.guihandles;
+
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+
+/**
+ * Provides a handle to a purhcase order card in the purchase order list panel.
+ */
+public class PurchaseOrderCardHandle extends NodeHandle<Node> {
+
+    private static final String ID_FIELD_ID = "#id";
+    private static final String SKU_FIELD_ID = "#sku";
+    private static final String QUANTITY_FIELD_ID = "#quantity";
+    private static final String REQUIRE_DATE_FIELD_ID = "#reqDate";
+    private static final String SUPPLIER_FIELD_ID = "#supplier";
+    private static final String STATUS_FIELD_ID = "#status";
+
+    private final Label idLabel;
+    private final Label skuLabel;
+    private final Label quantityLabel;
+    private final Label reqDateLabel;
+    private final Label supplierLabel;
+    private final Label statusLabel;
+
+    public PurchaseOrderCardHandle(Node cardNode) {
+        super(cardNode);
+
+        idLabel = getChildNode(ID_FIELD_ID);
+        skuLabel = getChildNode(SKU_FIELD_ID);
+        quantityLabel = getChildNode(QUANTITY_FIELD_ID);
+        reqDateLabel = getChildNode(REQUIRE_DATE_FIELD_ID);
+        supplierLabel = getChildNode(SUPPLIER_FIELD_ID);
+        statusLabel = getChildNode(STATUS_FIELD_ID);
+    }
+
+    public String getId() {
+        return idLabel.getText();
+    }
+
+    public String getSku() {
+        return skuLabel.getText();
+    }
+
+    public String getQuantity() {
+        return quantityLabel.getText();
+    }
+
+    public String getReqDate() {
+        return reqDateLabel.getText();
+    }
+
+    public String getSupplier() {
+        return supplierLabel.getText();
+    }
+
+    public String getStatus() {
+        return statusLabel.getText();
+    }
+
+    /**
+     * Returns true if this handle contains {@code po}.
+     */
+    public boolean equals(PurchaseOrder po) {
+        return getSku().equals(po.getSku().value)
+                && getQuantity().equals(po.getQuantity().value)
+                && getReqDate().equals(po.getReqDate().requiredDate)
+                && getSupplier().equals(po.getSupplier().supplierName)
+                && getStatus().equals(po.getStatus().name());
+    }
+}

--- a/src/test/java/guitests/guihandles/PurchaseOrderListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PurchaseOrderListPanelHandle.java
@@ -1,0 +1,160 @@
+package guitests.guihandles;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import javafx.scene.Node;
+import javafx.scene.control.ListView;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+
+/**
+ * Provides a handle for {@code PurchaseOrderListPanel} containing the list of {@code PurchaseOrderCard}.
+ */
+public class PurchaseOrderListPanelHandle extends NodeHandle<ListView<PurchaseOrder>> {
+
+    public static final String PO_LIST_VIEW_ID = "#purchaseOrderListView";
+
+    private static final String CARD_PANE_ID = "#cardPane";
+
+    private Optional<PurchaseOrder> lastRememberedSelectedPoCard;
+
+    public PurchaseOrderListPanelHandle(ListView<PurchaseOrder> poListPanelNode) {
+        super(poListPanelNode);
+    }
+
+    /**
+     * Returns a handle to the selected {@code PurchaseOrderCardHandle}.
+     * A maximum of 1 purchase order can be selected at any time.
+     * @throws AssertionError if no card is selected, or more than 1 card is selected.
+     * @throws IllegalStateException if the selected card is currently not in the scene graph.
+     */
+    public PurchaseOrderCardHandle getHandleToSelectedCard() {
+        List<PurchaseOrder> selectedPoList = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedPoList.size() != 1) {
+            throw new AssertionError("Purchase Order list size expected 1.");
+        }
+
+        return getAllCardNodes().stream()
+                .map(PurchaseOrderCardHandle::new)
+                .filter(handle -> handle.equals(selectedPoList.get(0)))
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
+    }
+
+    /**
+     * Returns the index of the selected card.
+     */
+    public int getSelectedCardIndex() {
+        return getRootNode().getSelectionModel().getSelectedIndex();
+    }
+
+    /**
+     * Returns true if a card is currently selected.
+     */
+    public boolean isAnyCardSelected() {
+        List<PurchaseOrder> selectedCardsList = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedCardsList.size() > 1) {
+            throw new AssertionError("Card list size expected 0 or 1.");
+        }
+
+        return !selectedCardsList.isEmpty();
+    }
+
+    /**
+     * Navigates the listview to display {@code po}.
+     */
+    public void navigateToCard(PurchaseOrder po) {
+        if (!getRootNode().getItems().contains(po)) {
+            throw new IllegalArgumentException("Purchase order does not exist.");
+        }
+
+        guiRobot.interact(() -> {
+            getRootNode().scrollTo(po);
+        });
+        guiRobot.pauseForHuman();
+    }
+
+    /**
+     * Navigates the listview to {@code index}.
+     */
+    public void navigateToCard(int index) {
+        if (index < 0 || index >= getRootNode().getItems().size()) {
+            throw new IllegalArgumentException("Index is out of bounds.");
+        }
+
+        guiRobot.interact(() -> {
+            getRootNode().scrollTo(index);
+        });
+        guiRobot.pauseForHuman();
+    }
+
+    /**
+     * Selects the {@code PurchaseOrderCard} at {@code index} in the list.
+     */
+    public void select(int index) {
+        getRootNode().getSelectionModel().select(index);
+    }
+
+    /**
+     * Returns the purchase order card handle of a purchase order associated with the {@code index} in the list.
+     * @throws IllegalStateException if the selected card is currently not in the scene graph.
+     */
+    public PurchaseOrderCardHandle getItemCardHandle(int index) {
+        return getAllCardNodes().stream()
+                .map(PurchaseOrderCardHandle::new)
+                .filter(handle -> handle.equals(getPurchaseOrder(index)))
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
+    }
+
+    private PurchaseOrder getPurchaseOrder(int index) {
+        return getRootNode().getItems().get(index);
+    }
+
+    /**
+     * Returns all card nodes in the scene graph.
+     * Card nodes that are visible in the listview are definitely in the scene graph, while some nodes that are not
+     * visible in the listview may also be in the scene graph.
+     */
+    private Set<Node> getAllCardNodes() {
+        return guiRobot.lookup(CARD_PANE_ID).queryAll();
+    }
+
+    /**
+     * Remembers the selected {@code PurchaseOrderCard} in the list.
+     */
+    public void rememberSelectedPoCard() {
+        List<PurchaseOrder> selectedPos = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedPos.size() == 0) {
+            lastRememberedSelectedPoCard = Optional.empty();
+        } else {
+            lastRememberedSelectedPoCard = Optional.of(selectedPos.get(0));
+        }
+    }
+
+    /**
+     * Returns true if the selected {@code PurchaseOrderCard} is different from the value remembered by the most recent
+     * {@code rememberSelectedPoCard()} call.
+     */
+    public boolean isSelectedPoCardChanged() {
+        List<PurchaseOrder> selectedPos = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedPos.size() == 0) {
+            return lastRememberedSelectedPoCard.isPresent();
+        } else {
+            return !lastRememberedSelectedPoCard.isPresent()
+                    || !lastRememberedSelectedPoCard.get().equals(selectedPos.get(0));
+        }
+    }
+
+    /**
+     * Returns the size of the list.
+     */
+    public int getListSize() {
+        return getRootNode().getItems().size();
+    }
+}

--- a/src/test/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParserTest.java
+++ b/src/test/java/seedu/inventory/logic/parser/purchaseorder/EditPurchaseOrderCommandParserTest.java
@@ -1,21 +1,32 @@
 package seedu.inventory.logic.parser.purchaseorder;
 
 import static seedu.inventory.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.inventory.logic.commands.CommandTestUtil.DESC_SONY_PO;
 import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_QUANTITY_DESC;
 import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_REQUIRED_DATE_DESC;
 import static seedu.inventory.logic.commands.CommandTestUtil.INVALID_SUPPLIER_DESC;
+import static seedu.inventory.logic.commands.CommandTestUtil.QUANTITY_DESC_OPPO;
 import static seedu.inventory.logic.commands.CommandTestUtil.QUANTITY_DESC_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.REQUIRED_DATE_DESC_OPPO;
 import static seedu.inventory.logic.commands.CommandTestUtil.REQUIRED_DATE_DESC_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.SUPPLIER_DESC_OPPO;
+import static seedu.inventory.logic.commands.CommandTestUtil.SUPPLIER_DESC_SONY;
 import static seedu.inventory.logic.commands.CommandTestUtil.VALID_QUANTITY_SONY;
+import static seedu.inventory.logic.commands.CommandTestUtil.VALID_REQUIRED_DATE_OPPO;
 import static seedu.inventory.logic.commands.CommandTestUtil.VALID_SUPPLIER_OPPO;
 import static seedu.inventory.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.inventory.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.inventory.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.inventory.testutil.TypicalIndexes.INDEX_THIRD_ITEM;
 
 import org.junit.Test;
 
+import seedu.inventory.commons.core.index.Index;
 import seedu.inventory.logic.commands.purchaseorder.EditPurchaseOrderCommand;
 import seedu.inventory.model.item.Quantity;
 import seedu.inventory.model.purchaseorder.RequiredDate;
 import seedu.inventory.model.purchaseorder.Supplier;
+import seedu.inventory.testutil.purchaseorder.EditPurchaseOrderDescriptorBuilder;
 
 
 public class EditPurchaseOrderCommandParserTest {
@@ -74,5 +85,51 @@ public class EditPurchaseOrderCommandParserTest {
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_QUANTITY_DESC + INVALID_REQUIRED_DATE_DESC + VALID_SUPPLIER_OPPO,
                 Quantity.MESSAGE_QUANTITY_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // quantity
+        Index targetIndex = INDEX_THIRD_ITEM;
+        String userInput = targetIndex.getOneBased() + QUANTITY_DESC_SONY;
+        EditPurchaseOrderCommand.EditPoDescriptor descriptor = new EditPurchaseOrderDescriptorBuilder()
+                .withQuantity(VALID_QUANTITY_SONY).build();
+        EditPurchaseOrderCommand expectedCommand = new EditPurchaseOrderCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // required date
+        userInput = targetIndex.getOneBased() + REQUIRED_DATE_DESC_OPPO;
+        descriptor = new EditPurchaseOrderDescriptorBuilder().withRequiredDate(VALID_REQUIRED_DATE_OPPO).build();
+        expectedCommand = new EditPurchaseOrderCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // supplier
+        userInput = targetIndex.getOneBased() + SUPPLIER_DESC_OPPO;
+        descriptor = new EditPurchaseOrderDescriptorBuilder().withSupplier(VALID_SUPPLIER_OPPO).build();
+        expectedCommand = new EditPurchaseOrderCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        Index targetIndex = INDEX_FIRST_ITEM;
+        String userInput = targetIndex.getOneBased() + QUANTITY_DESC_OPPO + QUANTITY_DESC_OPPO + QUANTITY_DESC_SONY;
+
+        EditPurchaseOrderCommand.EditPoDescriptor descriptor = new EditPurchaseOrderDescriptorBuilder()
+                .withQuantity(VALID_QUANTITY_SONY)
+                .build();
+        EditPurchaseOrderCommand expectedCommand = new EditPurchaseOrderCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_ITEM;
+        String userInput = targetIndex.getOneBased() + QUANTITY_DESC_SONY + REQUIRED_DATE_DESC_SONY
+                + SUPPLIER_DESC_SONY;
+
+        assertParseSuccess(parser, userInput, new EditPurchaseOrderCommand(INDEX_FIRST_ITEM, DESC_SONY_PO));
     }
 }

--- a/src/test/java/seedu/inventory/model/InventoryTest.java
+++ b/src/test/java/seedu/inventory/model/InventoryTest.java
@@ -185,10 +185,29 @@ public class InventoryTest {
     }
 
     @Test
+    public void hasPurchaseOrder_purchaseOrderInInventory_returnsTrue() {
+        inventory.addItem(IPHONE);
+        inventory.addPurchaseOrder(IPHONEPO);
+        assertTrue(inventory.hasPurchaseOrder(IPHONEPO));
+        assertTrue(inventory.hasPurchaseOrder(IPHONE));
+    }
+
+    @Test
     public void getPurchaseOrderList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         inventory.getPurchaseOrderList().remove(0);
     }
+
+    @Test
+    public void removePurchaseOrder() {
+        inventory.addItem(IPHONE);
+        assertFalse(inventory.hasPurchaseOrder(IPHONEPO));
+        inventory.addPurchaseOrder(IPHONEPO);
+        assertTrue(inventory.hasPurchaseOrder(IPHONEPO));
+        inventory.removePurchaseOrder(IPHONEPO);
+        assertFalse(inventory.hasPurchaseOrder(IPHONEPO));
+    }
+
 
     ////===================== Staff ==================================================================
 

--- a/src/test/java/seedu/inventory/model/ModelManagerTest.java
+++ b/src/test/java/seedu/inventory/model/ModelManagerTest.java
@@ -118,6 +118,28 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasPurchaseOrder_purchaseOrderInInventory_returnsTrue() {
+        modelManager.addItem(IPHONE);
+        modelManager.addPurchaseOrder(IPHONEPO);
+        assertTrue(modelManager.hasPurchaseOrder(IPHONEPO));
+        assertTrue(modelManager.hasPurchaseOrder(IPHONE));
+    }
+
+    @Test
+    public void deletePurchaseOrder() {
+        modelManager.addItem(IPHONE);
+        assertFalse(modelManager.hasPurchaseOrder(IPHONEPO));
+        modelManager.addPurchaseOrder(IPHONEPO);
+        assertTrue(modelManager.hasPurchaseOrder(IPHONEPO));
+        modelManager.deletePurchaseOrder(IPHONEPO);
+        assertFalse(modelManager.hasPurchaseOrder(IPHONEPO));
+
+        modelManager.addPurchaseOrder(IPHONEPO);
+        modelManager.deletePurchaseOrder(IPHONE);
+        assertFalse(modelManager.hasPurchaseOrder(IPHONEPO));
+    }
+
+    @Test
     public void getFilteredPurchaseOrderList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         modelManager.getFilteredPurchaseOrderList().remove(0);

--- a/src/test/java/seedu/inventory/testutil/ModelStub.java
+++ b/src/test/java/seedu/inventory/testutil/ModelStub.java
@@ -202,6 +202,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void updatePurchaseOrder(Item target, Item editedItem) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void approvePurchaseOrder(PurchaseOrder target) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/inventory/ui/PurchaseOrderCardTest.java
+++ b/src/test/java/seedu/inventory/ui/PurchaseOrderCardTest.java
@@ -1,0 +1,66 @@
+package seedu.inventory.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.inventory.ui.testutil.GuiTestAssert.assertCardDisplaysPurchaseOrder;
+
+import org.junit.Test;
+
+import guitests.guihandles.PurchaseOrderCardHandle;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+import seedu.inventory.testutil.purchaseorder.PurchaseOrderBuilder;
+import seedu.inventory.ui.purchaseorder.PurchaseOrderCard;
+
+public class PurchaseOrderCardTest extends GuiUnitTest {
+
+    @Test
+    public void display() {
+        PurchaseOrder po = new PurchaseOrderBuilder().build();
+        PurchaseOrderCard poCard = new PurchaseOrderCard(po, 1);
+        uiPartRule.setUiPart(poCard);
+        assertCardDisplay(poCard, po, 1);
+    }
+
+    @Test
+    public void equals() {
+        PurchaseOrder po = new PurchaseOrderBuilder().build();
+        PurchaseOrderCard poCard = new PurchaseOrderCard(po, 0);
+
+        // same po, same index -> returns true
+        PurchaseOrderCard copy = new PurchaseOrderCard(po, 0);
+        assertTrue(poCard.equals(copy));
+
+        // same object -> returns true
+        assertTrue(poCard.equals(poCard));
+
+        // null -> returns false
+        assertFalse(poCard.equals(null));
+
+        // different types -> returns false
+        assertFalse(poCard.equals(0));
+
+        // different PurchaseOrder, same index -> returns false
+        PurchaseOrder differentPo = new PurchaseOrderBuilder().withSku("different").build();
+        assertFalse(poCard.equals(new PurchaseOrderCard(differentPo, 0)));
+
+        // same PurchaseOrder, different index -> returns false
+        assertFalse(poCard.equals(new PurchaseOrderCard(po, 1)));
+    }
+
+    /**
+     * Asserts that {@code poCard} displays the details of {@code expectedPo} correctly and matches
+     * {@code expectedId}.
+     */
+    private void assertCardDisplay(PurchaseOrderCard poCard, PurchaseOrder expectedPo, int expectedId) {
+        guiRobot.pauseForHuman();
+
+        PurchaseOrderCardHandle poCardHandle = new PurchaseOrderCardHandle(poCard.getRoot());
+
+        // verify id is displayed correctly
+        assertEquals(Integer.toString(expectedId) + ". ", poCardHandle.getId());
+
+        // verify PurchaseOrder details are displayed correctly
+        assertCardDisplaysPurchaseOrder(expectedPo, poCardHandle);
+    }
+}

--- a/src/test/java/seedu/inventory/ui/PurchaseOrderListPanelTest.java
+++ b/src/test/java/seedu/inventory/ui/PurchaseOrderListPanelTest.java
@@ -1,0 +1,66 @@
+package seedu.inventory.ui;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.inventory.testutil.EventsUtil.postNow;
+import static seedu.inventory.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.inventory.testutil.purchaseorder.TypicalPurchaseOrder.getTypicalPurchaseOrder;
+import static seedu.inventory.ui.testutil.GuiTestAssert.assertCardDisplaysPurchaseOrder;
+import static seedu.inventory.ui.testutil.GuiTestAssert.assertCardEquals;
+
+import org.junit.Test;
+
+import guitests.guihandles.PurchaseOrderCardHandle;
+import guitests.guihandles.PurchaseOrderListPanelHandle;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.inventory.commons.events.ui.JumpToPurchaseOrderListRequestEvent;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
+import seedu.inventory.ui.purchaseorder.PurchaseOrderListPanel;
+
+public class PurchaseOrderListPanelTest extends GuiUnitTest {
+    private static final ObservableList<PurchaseOrder> TYPICAL_PO_LIST =
+            FXCollections.observableList(getTypicalPurchaseOrder());
+
+    private static final JumpToPurchaseOrderListRequestEvent JUMP_TO_SECOND_EVENT =
+            new JumpToPurchaseOrderListRequestEvent(INDEX_SECOND_ITEM);
+
+    private PurchaseOrderListPanelHandle poListPanelHandle;
+
+    @Test
+    public void display() {
+        initUi(TYPICAL_PO_LIST);
+
+        for (int i = 0; i < TYPICAL_PO_LIST.size(); i++) {
+            poListPanelHandle.navigateToCard(TYPICAL_PO_LIST.get(i));
+            PurchaseOrder expectedPo = TYPICAL_PO_LIST.get(i);
+            PurchaseOrderCardHandle actualCard = poListPanelHandle.getItemCardHandle(i);
+
+            assertCardDisplaysPurchaseOrder(expectedPo, actualCard);
+            assertEquals(Integer.toString(i + 1) + ". ", actualCard.getId());
+        }
+    }
+
+    @Test
+    public void handleJumpToListRequestEvent() {
+        initUi(TYPICAL_PO_LIST);
+        postNow(JUMP_TO_SECOND_EVENT);
+        guiRobot.pauseForHuman();
+
+        PurchaseOrderCardHandle expectedPo = poListPanelHandle.getItemCardHandle(INDEX_SECOND_ITEM.getZeroBased());
+        PurchaseOrderCardHandle selectedPo = poListPanelHandle.getHandleToSelectedCard();
+        assertCardEquals(expectedPo, selectedPo);
+    }
+
+
+    /**
+     * Initializes {@code poListPanelHandle} with a {@code PurchaseOrderListPanel} backed by {@code backingList}.
+     * Also shows the {@code Stage} that displays only {@code PurchaseOrderListPanel}.
+     */
+    private void initUi(ObservableList<PurchaseOrder> backingList) {
+        PurchaseOrderListPanel poListPanel = new PurchaseOrderListPanel(backingList);
+        uiPartRule.setUiPart(poListPanel);
+
+        poListPanelHandle = new PurchaseOrderListPanelHandle(getChildNode(poListPanel.getRoot(),
+                PurchaseOrderListPanelHandle.PO_LIST_VIEW_ID));
+    }
+}

--- a/src/test/java/seedu/inventory/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/inventory/ui/testutil/GuiTestAssert.java
@@ -7,10 +7,12 @@ import java.util.stream.Collectors;
 
 import guitests.guihandles.ItemCardHandle;
 import guitests.guihandles.ItemListPanelHandle;
+import guitests.guihandles.PurchaseOrderCardHandle;
 import guitests.guihandles.ResultDisplayHandle;
 import guitests.guihandles.SaleCardHandle;
 import guitests.guihandles.StaffCardHandle;
 import seedu.inventory.model.item.Item;
+import seedu.inventory.model.purchaseorder.PurchaseOrder;
 import seedu.inventory.model.sale.Sale;
 import seedu.inventory.model.staff.Staff;
 
@@ -41,6 +43,19 @@ public class GuiTestAssert {
     }
 
     /**
+     * Asserts that {@code actualCard} displays the same values as {@code expectedCard}.
+     */
+    public static void assertCardEquals(PurchaseOrderCardHandle expectedCard, PurchaseOrderCardHandle actualCard) {
+        assertEquals(expectedCard.getId(), actualCard.getId());
+        assertEquals(expectedCard.getSku(), actualCard.getSku());
+        assertEquals(expectedCard.getQuantity(), actualCard.getQuantity());
+        assertEquals(expectedCard.getReqDate(), actualCard.getReqDate());
+        assertEquals(expectedCard.getSupplier(), actualCard.getSupplier());
+        assertEquals(expectedCard.getStatus(), actualCard.getStatus());
+
+    }
+
+    /**
      * Asserts that {@code actualCard} displays the details of {@code expectedItem}.
      */
     public static void assertCardDisplaysItem(Item expectedItem, ItemCardHandle actualCard) {
@@ -67,6 +82,18 @@ public class GuiTestAssert {
         assertEquals(expectedStaff.getUsername().username, actualCard.getUsername());
         assertEquals(expectedStaff.getStaffName().fullName, actualCard.getName());
         assertEquals(expectedStaff.getRole().toString(), actualCard.getRole());
+    }
+
+    /**
+     * Asserts that {@code actualCard} displays the details of {@code expectedPo}.
+     */
+    public static void assertCardDisplaysPurchaseOrder(PurchaseOrder expectedPo, PurchaseOrderCardHandle actualCard) {
+        assertEquals(expectedPo.getSku().value, actualCard.getSku());
+        assertEquals(expectedPo.getQuantity().value, actualCard.getQuantity());
+        assertEquals(expectedPo.getReqDate().requiredDate, actualCard.getReqDate());
+        assertEquals(expectedPo.getSupplier().supplierName, actualCard.getSupplier());
+        assertEquals(expectedPo.getStatus().name(), actualCard.getStatus());
+
     }
 
     /**


### PR DESCRIPTION
This PR resolves #127
Fixed the issue of purchase order sku not updating when item's sku is edited.
