### PR TITLE
Fixed up the issues raised in PE dry run

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -320,7 +320,7 @@ An item can have any number of tags (including 0)
 
 Example:
 
-* `add n/IPhone X p/1600 q/1000 s/SN-1234 i/docs/images/iphone.jpg t/smartphone t/apple`
+* `add-item n/IPhone X p/1600 q/1000 s/SN-1234 i/docs/images/iphone.jpg t/smartphone t/apple`
 
 ==== Listing all items : `list-item`
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -303,6 +303,11 @@ Examples:
 
 The following commands are mainly used for users to manage the items stored in the inventory.
 
+[NOTE]
+====
+An item's uniqueness is based on its SKU. It can have the same name and other attributes but its SKU must be unique.
+====
+
 ==== Adding an item : `add-item`
 
 The `add-item` command adds an item to the inventory manager. +
@@ -315,7 +320,7 @@ An item can have any number of tags (including 0)
 
 Example:
 
-* `add n/IPhone X p/1600 q/1000 s/SN-1234 i/docs/images/iphone.jpg t/12-12-2012`
+* `add n/IPhone X p/1600 q/1000 s/SN-1234 i/docs/images/iphone.jpg t/smartphone t/apple`
 
 ==== Listing all items : `list-item`
 

--- a/src/main/java/seedu/inventory/logic/commands/item/AddItemCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/item/AddItemCommand.java
@@ -40,7 +40,7 @@ public class AddItemCommand extends Command {
             + PREFIX_TAG + "smartphone";
 
     public static final String MESSAGE_SUCCESS = "New item added: %1$s";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the inventory";
+    public static final String MESSAGE_DUPLICATE_ITEM = "Item with the same SKU already exists in the inventory";
 
     private final Item toAdd;
 

--- a/src/main/java/seedu/inventory/model/item/FilterPrice.java
+++ b/src/main/java/seedu/inventory/model/item/FilterPrice.java
@@ -9,10 +9,9 @@ import static seedu.inventory.commons.util.AppUtil.checkArgument;
  */
 public class FilterPrice {
 
-
     public static final String MESSAGE_PRICE_CONSTRAINTS =
-            "Filter Price should only contain numbers and/or a decimal point, and it should be at least 1 digit long. "
-            + "Price can only contain a maximum of 8 digits before the decimal point, "
+            "Filter Price should only contain positive integers and/or a decimal point, and it should be at least "
+            + " 1 digit long. Price can only contain a maximum of 8 digits before the decimal point, "
             + "and 2 digits after the decimal point. A prefix of '<' or '>' is required to indicate what the "
             + "condition for filtering is.";
 

--- a/src/main/java/seedu/inventory/model/item/FilterQuantity.java
+++ b/src/main/java/seedu/inventory/model/item/FilterQuantity.java
@@ -9,9 +9,8 @@ import static seedu.inventory.commons.util.AppUtil.checkArgument;
  */
 public class FilterQuantity {
 
-
     public static final String MESSAGE_QUANTITY_CONSTRAINTS =
-            "Filter Quantity should only contain numbers, and it should be at least 1 digit long. "
+            "Filter Quantity should only contain positive integers, and it should be at least 1 digit long. "
             + "Quantity can only contain a maximum of 8 digits before the decimal point, "
             + "and 2 digits after the decimal point. A prefix of '<' or '>' is required to indicate what the "
             + "condition for filtering is.";

--- a/src/main/java/seedu/inventory/model/item/Quantity.java
+++ b/src/main/java/seedu/inventory/model/item/Quantity.java
@@ -11,7 +11,7 @@ public class Quantity {
 
 
     public static final String MESSAGE_QUANTITY_CONSTRAINTS =
-            "Quantity should only contain numbers, and it should not start with a 0";
+            "Quantity should only contain positive numbers. Decimals or other characters are not allowed.";
     public static final String QUANTITY_VALIDATION_REGEX = "\\d{1,}";
     public final String value;
 
@@ -23,7 +23,7 @@ public class Quantity {
     public Quantity(String quantity) {
         requireNonNull(quantity);
         checkArgument(isValidQuantity(quantity), MESSAGE_QUANTITY_CONSTRAINTS);
-        value = quantity;
+        value = quantity.replaceFirst("^0+(?!$)", "");
     }
 
     /**


### PR DESCRIPTION
This PR addresses issues #160, #161, #163, #167, #181

- Updated MESSAGE_DUPLICATE_ITEM to clarify that an item with the same SKU already exists in the inventory. This addresses issues #160 and #161 
-  Updated User Guide add further clarification that an item's uniqueness is based on its SKU.. This addresses issues #160 and #161 
- Updated User Guide to fix up a wrong example given in the add-item command section, specifically the Example given.  This addresses issue #167 
- Updated MESSAGE_PRICE_CONSTRAINTS and MESSAGE_QUANTITY_CONSTRAINTS for FilterPrice and FilterQuantity respectively to clarify even further that no negative integers are allowed, in case users get confused and start adding negative numbers to quantities and prices and think that the message displayed isn't clear enough for them. This addresses issue #163 
- Updated MESSAGE_QUANTITY_CONSTRAINTS for Quantity to clarify and be more specific as to what a 'Quantity' should comprise of. This somewhat addresses issue #181