### PR TITLE
Resolves bugs found PE Dry Run.

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -206,7 +206,8 @@ Examples:
 
 ==== Change user's password : `change-password`
 
-The `change-password` command updates a user information into the system with given new password. +
+The `change-password` command updates a user password into the system with given new password. +
+If there are multiple inputs for the new password, then only the last input of the new password is accepted. +
 This command is available to *members* only. +
 
 image::doc-change-password.png[width="790"]

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -98,7 +98,7 @@ Format: `help`
 
 ==== Listing entered commands : `history`
 
-The `history` command lists all the commands that you have entered in reverse chronological order. +
+The `history` command lists all the commands that you have entered, including valid and invalid commands, in reverse chronological order. +
 This command is available to *any user*. +
 
 Format: `history`
@@ -169,7 +169,7 @@ Examples:
 ==== Clearing all entries : `clear`
 
 The `clear` command clears all entries from Inventory Manager. +
-This command is available to *members* only. +
+This command is available to *admin* only. +
 
 Format: `clear`
 

--- a/src/main/java/seedu/inventory/logic/CommandHistory.java
+++ b/src/main/java/seedu/inventory/logic/CommandHistory.java
@@ -28,6 +28,13 @@ public class CommandHistory {
     }
 
     /**
+     * Deletes all the history that the user has entered.
+     */
+    public void clear() {
+        userInputHistory.clear();
+    }
+
+    /**
      * Returns a defensive copy of {@code userInputHistory}.
      */
     public List<String> getHistory() {

--- a/src/main/java/seedu/inventory/logic/LogicManager.java
+++ b/src/main/java/seedu/inventory/logic/LogicManager.java
@@ -33,8 +33,8 @@ import seedu.inventory.model.staff.Staff;
  */
 public class LogicManager extends ComponentManager implements Logic {
 
-    private static final String MESSAGE_NO_ACCESS = "You have no permission to use this command.";
-    private static final String MESSAGE_NOT_LOGGED_IN = "You have not logged in.";
+    public static final String MESSAGE_NO_ACCESS = "You have no permission to use this command.";
+    public static final String MESSAGE_NOT_LOGGED_IN = "You have not logged in.";
 
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 

--- a/src/main/java/seedu/inventory/logic/LogicManager.java
+++ b/src/main/java/seedu/inventory/logic/LogicManager.java
@@ -10,6 +10,7 @@ import seedu.inventory.logic.commands.Command;
 import seedu.inventory.logic.commands.CommandResult;
 import seedu.inventory.logic.commands.ExitCommand;
 import seedu.inventory.logic.commands.HelpCommand;
+import seedu.inventory.logic.commands.HistoryCommand;
 import seedu.inventory.logic.commands.authentication.LoginCommand;
 import seedu.inventory.logic.commands.exceptions.CommandException;
 import seedu.inventory.logic.commands.purchaseorder.ApprovePurchaseOrderCommand;
@@ -89,7 +90,8 @@ public class LogicManager extends ComponentManager implements Logic {
 
     @Override
     public boolean isPublicCommand(Command command) {
-        return command instanceof HelpCommand || command instanceof LoginCommand || command instanceof ExitCommand;
+        return command instanceof HelpCommand || command instanceof LoginCommand || command instanceof ExitCommand
+                || command instanceof HistoryCommand;
     }
 
     @Override

--- a/src/main/java/seedu/inventory/logic/LogicManager.java
+++ b/src/main/java/seedu/inventory/logic/LogicManager.java
@@ -12,6 +12,7 @@ import seedu.inventory.logic.commands.ExitCommand;
 import seedu.inventory.logic.commands.HelpCommand;
 import seedu.inventory.logic.commands.HistoryCommand;
 import seedu.inventory.logic.commands.authentication.LoginCommand;
+import seedu.inventory.logic.commands.authentication.LogoutCommand;
 import seedu.inventory.logic.commands.exceptions.CommandException;
 import seedu.inventory.logic.commands.purchaseorder.ApprovePurchaseOrderCommand;
 import seedu.inventory.logic.commands.purchaseorder.RejectPurchaseOrderCommand;
@@ -50,6 +51,7 @@ public class LogicManager extends ComponentManager implements Logic {
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
+        boolean isLogoutCommand = false;
         try {
             Command command = inventoryParser.parseCommand(commandText);
 
@@ -57,9 +59,16 @@ public class LogicManager extends ComponentManager implements Logic {
                 throw new CommandException(MESSAGE_NOT_LOGGED_IN);
             }
             checkIsValidRole(command);
+            if (command instanceof LogoutCommand) {
+                isLogoutCommand = true;
+            }
             return command.execute(model, history);
         } finally {
-            history.add(commandText);
+            if (isLogoutCommand) {
+                history.clear();
+            } else {
+                history.add(commandText);
+            }
         }
     }
 

--- a/src/main/java/seedu/inventory/logic/commands/authentication/LoginCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/authentication/LoginCommand.java
@@ -18,12 +18,12 @@ public class LoginCommand extends Command {
 
     public static final String COMMAND_WORD = "login";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Login an user into the system."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Login an user into the system. "
             + "Parameters: "
             + PREFIX_USERNAME + "USERNAME "
             + PREFIX_PASSWORD + "PASSWORD \n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_USERNAME + "user2"
+            + PREFIX_USERNAME + "user2 "
             + PREFIX_PASSWORD + "12345678";
 
     public static final String MESSAGE_SUCCESS = "You have successfully logged in as %s";
@@ -52,7 +52,6 @@ public class LoginCommand extends Command {
 
         Staff staff = model.retrieveStaff(toLogin);
         model.authenticateUser(staff);
-        model.commitInventory();
         return new CommandResult(String.format(MESSAGE_SUCCESS, staff.getStaffName()));
     }
 

--- a/src/main/java/seedu/inventory/logic/commands/authentication/LogoutCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/authentication/LogoutCommand.java
@@ -16,7 +16,8 @@ public class LogoutCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Log an user out from the system.";
 
-    public static final String MESSAGE_SUCCESS = "You have successfully logged out from the system.";
+    public static final String MESSAGE_SUCCESS = "You have successfully logged out from the system.\n"
+            + "All commands history are cleared.";
     public static final String MESSAGE_FAILED = "You are not logged in.";
 
     @Override

--- a/src/main/java/seedu/inventory/logic/commands/staff/DeleteStaffCommand.java
+++ b/src/main/java/seedu/inventory/logic/commands/staff/DeleteStaffCommand.java
@@ -26,6 +26,7 @@ public class DeleteStaffCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_STAFF_SUCCESS = "Deleted Staff: %1$s";
+    public static final String MESSAGE_DELETE_SELF_FAILED = "You cannot delete yourself.";
 
     private final Index targetIndex;
 
@@ -43,6 +44,9 @@ public class DeleteStaffCommand extends Command {
         }
 
         Staff staffToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (staffToDelete.equals(model.getUser())) {
+            throw new CommandException(MESSAGE_DELETE_SELF_FAILED);
+        }
         model.deleteStaff(staffToDelete);
         model.commitInventory();
         return new CommandResult(String.format(MESSAGE_DELETE_STAFF_SUCCESS, staffToDelete));

--- a/src/test/java/seedu/inventory/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/inventory/logic/CommandHistoryTest.java
@@ -37,6 +37,17 @@ public class CommandHistoryTest {
     }
 
     @Test
+    public void clear() {
+        final String validCommand = "clear";
+        final String invalidCommand = "adds Bob";
+
+        history.add(validCommand);
+        history.add(invalidCommand);
+        history.clear();
+        assertEquals(Arrays.asList(), history.getHistory());
+    }
+
+    @Test
     public void equals() {
         final CommandHistory commandHistoryWithA = new CommandHistory();
         commandHistoryWithA.add("a");

--- a/src/test/java/seedu/inventory/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/inventory/logic/LogicManagerTest.java
@@ -19,6 +19,7 @@ import seedu.inventory.logic.commands.ExitCommand;
 import seedu.inventory.logic.commands.HelpCommand;
 import seedu.inventory.logic.commands.HistoryCommand;
 import seedu.inventory.logic.commands.authentication.LoginCommand;
+import seedu.inventory.logic.commands.authentication.LogoutCommand;
 import seedu.inventory.logic.commands.exceptions.CommandException;
 import seedu.inventory.logic.commands.item.ListItemCommand;
 import seedu.inventory.logic.commands.purchaseorder.ApprovePurchaseOrderCommand;
@@ -73,6 +74,19 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_invalidRole_failure() {
+        String deleteStaffCommand = "delete-staff 1";
+        assertCommandException(deleteStaffCommand, LogicManager.MESSAGE_NO_ACCESS);
+    }
+
+    @Test
+    public void execute_logoutCommand_historyCleared() {
+        String logoutCommand = LogoutCommand.COMMAND_WORD;
+        assertCommandSuccess(logoutCommand, LogoutCommand.MESSAGE_SUCCESS, model);
+        assertHistoryEmpty();
+    }
+
+    @Test
     public void isPublicCommand() {
         Staff staff = new StaffBuilder().build();
 
@@ -85,7 +99,7 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void isUserManagementCommand() {
+    public void isAdminCommand() {
         Staff staff = new StaffBuilder().build();
 
         assertFalse(logic.isAdminCommand(new HelpCommand()));
@@ -190,6 +204,21 @@ public class LogicManagerTest {
             CommandResult result = logic.execute(HistoryCommand.COMMAND_WORD);
             String expectedMessage = String.format(
                     HistoryCommand.MESSAGE_SUCCESS, String.join("\n", expectedCommands));
+            assertEquals(expectedMessage, result.feedbackToUser);
+        } catch (ParseException | CommandException e) {
+            throw new AssertionError("Parsing and execution of HistoryCommand.COMMAND_WORD should succeed.", e);
+        }
+    }
+
+    /**
+     * Asserts that the result display shows empty history upon the execution of
+     * {@code HistoryCommand}.
+     */
+    private void assertHistoryEmpty() {
+        try {
+            CommandResult result = logic.execute(HistoryCommand.COMMAND_WORD);
+            String expectedMessage = String.format(
+                    HistoryCommand.MESSAGE_NO_HISTORY);
             assertEquals(expectedMessage, result.feedbackToUser);
         } catch (ParseException | CommandException e) {
             throw new AssertionError("Parsing and execution of HistoryCommand.COMMAND_WORD should succeed.", e);


### PR DESCRIPTION
This Pull Request will close #156 , #162 , #165 , #166 , #170 , #173 ,#177 , #180 , #184 .
- `history` command is now allowed to be accessed by all users including non-logged in users. This resolves #156 and #162 .
- To prevent other users can accessed the history of the previous user, history will be cleared once the user logged out. This resolves #173 and #177 .
- Examples given in the application for `login` command has been corrected. This resolves #166 .
- `history` commands' behavior has been updated to be more concise. This resolves #165 .
- `change-password` command has now been described how it would behavior if there are multiple inputs given. This resolves #184 .
- `undo` is now unable to undo after logged in. This resolves #180 .